### PR TITLE
[DEV-3188] Add support for single-shot jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2022-01-28
+
+### Added
+
+- Support single-shot jobs by specifying a zero-length duration like `PT0M`
+
 ## [1.0.0] - 2021-08-09
 
 ### Added
 
 - Initial release
 
-[unreleased]: https://github.com/sasquatch/micro-job-scheduler/compare/v1.0.0...HEAD
+[unreleased]: https://github.com/sasquatch/micro-job-scheduler/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/sasquatch/micro-job-scheduler/releases/tag/v1.1.0
 [1.0.0]: https://github.com/sasquatch/micro-job-scheduler/releases/tag/v1.0.0

--- a/README.md
+++ b/README.md
@@ -64,7 +64,10 @@ Stop the job scheduler.
 
 Add a job with the given options, and the given data. Options you can pass are:
 
-- `durationBetweenRuns`: An ISO8601 duration string, like `PT5M` to indicate 5 minutes
+- `durationBetweenRuns`: An ISO8601 duration string, like `PT5M` to indicate 5 minutes.
+  Use `PT0M` (or anything else that is a valid ISO8601 duration that is 0 seconds long)
+  for a single-shot job that should only be run once, and removed from the scheduler
+  when it completes (successfully or unsuccessfully).
 - `concurrencyKey`: A string which groups jobs together for the purpose of concurrency
 - `fn`: The function to run your job, with the signature `fn(job: Job): Promise<any>`.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "micro-job-scheduler",
-  "version": "1.0.0",
+  "version": "1.1.0-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "micro-job-scheduler",
-  "version": "1.1.0-0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "micro-job-scheduler",
-  "version": "1.0.0",
+  "version": "1.1.0-0",
   "description": "Promise-based in-memory micro job scheduler",
   "files": [
     "dist/"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "micro-job-scheduler",
-  "version": "1.1.0-0",
+  "version": "1.1.0",
   "description": "Promise-based in-memory micro job scheduler",
   "files": [
     "dist/"


### PR DESCRIPTION
## Description of the change

Add support for single-shot jobs, which are specified with a zero-duration interval. This allows a job to run once, and then be removed from the scheduler.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation or Development tools (readme, specs, tests, code formatting)

## Links

 - Jira issue number: DEV-3188
 - Process.st launch checklist: https://app.process.st/runs/DEV-3188-SFTP-Import-Integration-koCSVi-DDB9cLOiHiKZN9w

## Checklists

### Development

- [x] [Prettier](https://www.npmjs.com/package/prettier) was run
- [x] The behaviour changes in the pull request are covered by specs
- [x] All tests related to the changed code pass in development

### Paperwork

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has a Jira number
- [x] This pull request has a Process.st launch checklist

### Code review 

- [x] Changes have been reviewed by at least one other engineer
- [x] Security impacts of this change have been considered
